### PR TITLE
Fix scanning of subkeys

### DIFF
--- a/lib/KeySigningParty/GPG.pm
+++ b/lib/KeySigningParty/GPG.pm
@@ -200,7 +200,7 @@ sub _build_keys_hash {
 #			die Dumper( [ $cur_key ] );
 		}
 
-		if ( $type eq "fpr" ) {
+		if ( $type eq "fpr" and !$cur_key->fingerprint) {
 			$cur_key->fingerprint($data);
 		}
 	}


### PR DESCRIPTION
Without this, `scanlist` will think the correct fingerprint is one of the subkeys, which is not the one in the key list.
